### PR TITLE
Supported additional Redmine patches and use Redmica 1.2 as default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,11 @@ services:
       context: ./
       dockerfile: ./Dockerfile
       args:
-        REDMINE_VERSION: 4.0.7
-        REDMICA_VERSION: ""
-        GEM_PG_VERSION: 1.1.4
+        REDMINE_VERSION: ""
+        REDMICA_VERSION: 1.2.0
+        GEM_PG_VERSION: 1.2.2
+        PATCH_STRIP: 1
+        PATCH_DIRS: "33290"
     ports:
       - 3000:3000
     environment:
@@ -18,7 +20,7 @@ services:
       REDMINE_DB_PASSWORD: gtt
       REDMINE_DB_DATABASE: gtt
       REDMINE_PLUGINS_MIGRATE: 1
-      GEM_PG_VERSION: 1.1.4
+      GEM_PG_VERSION: 1.2.2
     volumes:
       - ./files:/usr/src/redmine/files
       - ./plugins:/usr/src/redmine/plugins

--- a/patches/33290/0001-stop-db-access-on-class-definition-v2.patch
+++ b/patches/33290/0001-stop-db-access-on-class-definition-v2.patch
@@ -1,0 +1,115 @@
+From 2022921f470eae0458683780156d429568e84077 Mon Sep 17 00:00:00 2001
+From: Kevin Fischer <kevin@agileware.jp>
+Date: Fri, 5 Feb 2021 10:44:35 +0000
+Subject: Patch for fix/issue-query-definition
+
+---
+ app/models/query.rb | 40 +++++++++++++++++++++++++++-------------
+ 1 file changed, 27 insertions(+), 13 deletions(-)
+
+diff --git a/app/models/query.rb b/app/models/query.rb
+index 039e38e32..95701dfa1 100644
+--- a/app/models/query.rb
++++ b/app/models/query.rb
+@@ -20,17 +20,14 @@
+ require 'redmine/sort_criteria'
+ 
+ class QueryColumn
+-  attr_accessor :name, :groupable, :totalable, :default_order
+-  attr_writer   :sortable
++  attr_accessor :name, :totalable, :default_order
++  attr_writer   :sortable, :groupable
+   include Redmine::I18n
+ 
+   def initialize(name, options={})
+     self.name = name
+     self.sortable = options[:sortable]
+     self.groupable = options[:groupable] || false
+-    if groupable == true
+-      self.groupable = name.to_s
+-    end
+     self.totalable = options[:totalable] || false
+     self.default_order = options[:default_order]
+     @inline = options.key?(:inline) ? options[:inline] : true
+@@ -49,6 +46,10 @@ class QueryColumn
+     end
+   end
+ 
++  def groupable?
++    @groupable
++  end
++
+   # Returns true if the column is sortable, otherwise false
+   def sortable?
+     !@sortable.nil?
+@@ -82,13 +83,19 @@ class QueryColumn
+   def css_classes
+     name
+   end
++
++  def group_by_statement
++    name.to_s
++  end
+ end
+ 
+ class TimestampQueryColumn < QueryColumn
+-  def groupable
+-    if @groupable
+-      Redmine::Database.timestamp_to_date(sortable, User.current.time_zone)
+-    end
++  def groupable?
++    group_by_statement.present?
++  end
++
++  def group_by_statement
++    Redmine::Database.timestamp_to_date(sortable, User.current.time_zone)
+   end
+ 
+   def group_value(object)
+@@ -121,12 +128,19 @@ class QueryCustomFieldColumn < QueryColumn
+   def initialize(custom_field, options={})
+     self.name = "cf_#{custom_field.id}".to_sym
+     self.sortable = custom_field.order_statement || false
+-    self.groupable = custom_field.group_statement || false
+     self.totalable = options.key?(:totalable) ? !!options[:totalable] : custom_field.totalable?
+     @inline = custom_field.full_width_layout? ? false : true
+     @cf = custom_field
+   end
+ 
++  def groupable?
++    group_by_statement.present?
++  end
++
++  def group_by_statement
++    @cf.group_statement
++  end
++
+   def caption
+     @cf.name
+   end
+@@ -741,7 +755,7 @@ class Query < ActiveRecord::Base
+ 
+   # Returns an array of columns that can be used to group the results
+   def groupable_columns
+-    available_columns.select {|c| c.groupable}
++    available_columns.select {|c| c.groupable?}
+   end
+ 
+   # Returns a Hash of columns and the key for sorting
+@@ -889,11 +903,11 @@ class Query < ActiveRecord::Base
+   end
+ 
+   def group_by_column
+-    groupable_columns.detect {|c| c.groupable && c.name.to_s == group_by}
++    groupable_columns.detect {|c| c.groupable? && c.name.to_s == group_by}
+   end
+ 
+   def group_by_statement
+-    group_by_column.try(:groupable)
++    group_by_column.try(:group_by_statement)
+   end
+ 
+   def project_statement
+-- 
+2.30.0
+


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes #12.

Changes proposed in this pull request:
- Support additional Redmine patches in `./patches` folder.
   - Docker build arguments are:
      - `PATCH_STRIP`: patch command's strip folder level
      - `PATCH_DIRS`: patch directories (as relative) in `./patch` directory.
- Add https://www.redmine.org/issues/33290 patch to support Redmine >= 4.1 and Redmica >= 1.0.
- Use Redmica 1.2 (latest) as default.

@gtt-project/maintainer
