### PR TITLE
Supported basic configuration.yml with .env.example for smtp settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Gemfile
+GEM_PG_VERSION=1.2.2
+
+# config/configuration.yml
+SMTP_ENABLE_STARTTLS_AUTO=true # (or false)
+SMTP_ADDRESS=smtp.gmail.com
+SMTP_PORT=587
+SMTP_DOMAIN=smtp.gmail.com
+SMTP_AUTHENTICATION=plain # (or login)
+SMTP_USER_NAME=YOUR_EMAIL_ADDRESS
+SMTP_PASSWORD=YOUR_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,7 @@ RUN set -eux; \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
+COPY config/ ./config/
 VOLUME /usr/src/redmine/files
 
 COPY docker-entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ After cloning this repository run:
 
 ```
 git submodule update --init
+cp .env.example .env
 docker-compose up --build
 ```
 

--- a/config/configuration.yml
+++ b/config/configuration.yml
@@ -1,0 +1,35 @@
+# = Redmine configuration file
+#
+# Each environment has its own configuration options.  If you are only
+# running in production, only the production block needs to be configured.
+# Environment specific configuration options override the default ones.
+#
+# Note that this file needs to be a valid YAML file.
+# DO NOT USE TABS! Use 2 spaces instead of tabs for indentation.
+
+# default configuration options for all environments
+default:
+  # Outgoing emails configuration
+  # See the examples below and the Rails guide for more configuration options:
+  # http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
+  #  email_delivery:
+
+  # ==== SMTP server at using TLS (GMail)
+  # This might require some additional configuration. See the guides at:
+  # http://www.redmine.org/projects/redmine/wiki/EmailConfiguration
+  #
+  email_delivery:
+    delivery_method: :smtp
+    smtp_settings:
+      enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] %>
+      address: <%= ENV['SMTP_ADDRESS'] %>
+      port: <%= ENV['SMTP_PORT'] %>
+      domain: <%= ENV['SMTP_DOMAIN'] %>
+      authentication: <%= ENV['SMTP_AUTHENTICATION'] %>
+      user_name: <%= ENV['SMTP_USER_NAME'] %>
+      password: <%= ENV['SMTP_PASSWORD'] %>
+ 
+  # ==== Sendmail command
+  #
+  #  email_delivery:
+  #    delivery_method: :sendmail

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       args:
         REDMINE_VERSION: ""
         REDMICA_VERSION: 1.2.0
-        GEM_PG_VERSION: 1.2.2
+        GEM_PG_VERSION: ${GEM_PG_VERSION}
         PATCH_STRIP: 1
         PATCH_DIRS: "33290"
     ports:
@@ -20,7 +20,16 @@ services:
       REDMINE_DB_PASSWORD: gtt
       REDMINE_DB_DATABASE: gtt
       REDMINE_PLUGINS_MIGRATE: 1
-      GEM_PG_VERSION: 1.2.2
+      # Gemfile
+      GEM_PG_VERSION: ${GEM_PG_VERSION}
+      # config/configuration.yml
+      SMTP_ENABLE_STARTTLS_AUTO: ${SMTP_ENABLE_STARTTLS_AUTO}
+      SMTP_ADDRESS: ${SMTP_ADDRESS}
+      SMTP_PORT: ${SMTP_PORT}
+      SMTP_DOMAIN: ${SMTP_DOMAIN}
+      SMTP_AUTHENTICATION: ${SMTP_AUTHENTICATION}
+      SMTP_USER_NAME: ${SMTP_USER_NAME}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
     volumes:
       - ./files:/usr/src/redmine/files
       - ./plugins:/usr/src/redmine/plugins


### PR DESCRIPTION
Supports #17.

Changes proposed in this pull request:
- Added `.env.example` for basic smtp settings (Gmail example values in Redmine original `configuration.yml.example`
- Pass `.env` environment variables to Docker container via `docker-compose.yml`
- Added `config/configuration.yml` which reads setting variables from environment variables.
- Copy `config/configuration.yml` during Docker image build.

@gtt-project/maintainer
