### PR TITLE
Define DB parameters as environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Gemfile
 GEM_PG_VERSION=1.2.2
 
+# docker-compose.yml - postgres
+POSTGRES_USER=gtt
+POSTGRES_PASSWORD=gtt
+POSTGRES_DB=gtt
+
 # config/configuration.yml
 SMTP_ENABLE_STARTTLS_AUTO=true # (or false)
 SMTP_ADDRESS=smtp.gmail.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - 3000:3000
     environment:
       REDMINE_DB_POSTGRES: postgres
-      REDMINE_DB_USERNAME: gtt
-      REDMINE_DB_PASSWORD: gtt
-      REDMINE_DB_DATABASE: gtt
+      REDMINE_DB_USERNAME: ${POSTGRES_USER}
+      REDMINE_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      REDMINE_DB_DATABASE: ${POSTGRES_DB}
       REDMINE_PLUGINS_MIGRATE: 1
       # Gemfile
       GEM_PG_VERSION: ${GEM_PG_VERSION}
@@ -42,9 +42,9 @@ services:
   postgres:
     image: postgis/postgis:latest
     environment:
-      POSTGRES_USER: gtt
-      POSTGRES_PASSWORD: gtt
-      POSTGRES_DB: gtt
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - postgres:/var/lib/postgresql/data
     restart: always


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Changes proposed in this pull request:
- I moved DB parameters to `.env.example` file.
- Keep original params (all `gtt`) as example (to ensure that just copying `.env.example` to `.env` works without problem).

@gtt-project/maintainer
