### PR TITLE
Supported redmine_gtt webpack build on docker host side

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,25 @@
 
 Docker image for GTT Project
 
+## Requirements
+
+- Docker
+- docker-compose
+- NodeJS v14
+- yarn
+
 ## Quick start
 
 After cloning this repository run:
 
 ```
 git submodule update --init
+
+cd plugins/redmine_gtt
+yarn
+npx webpack
+cd ../../
+
 cp .env.example .env
 docker-compose up --build
 ```


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Supports #25 as a workaround.

Changes proposed in this pull request:
- Add webpack build steps on the `README.md` file.
- Update `redmine_gtt` submodule commit to point the latest `develop` branch.

@gtt-project/maintainer
