### PR TITLE
Support npx webpack build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.DS_Store
+
+# plugins/redmine_gtt
+plugins/redmine_gtt/node_modules
+plugins/redmine_gtt/assets/javascripts
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends yarn; \
 	for plugin in ./plugins/*; do \
 		if [ -f "$plugin/webpack.config.js" ]; then \
-			cd "$plugin" && yarn && npx webpack && cd ../..; \
+			cd "$plugin" && yarn && npx webpack && rm -rf node_modules && cd ../..; \
 		fi; \
 	done; \
 	export GEM_PG_VERSION="$GEM_PG_VERSION"; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       - ./files:/usr/src/redmine/files
       - ./plugins:/usr/src/redmine/plugins
       - ./public/themes:/usr/src/redmine/public/themes
+      # Exclude node package and webpack contents folders
+      - /usr/src/redmine/plugins/redmine_gtt/node_modules
+      - /usr/src/redmine/plugins/redmine_gtt/assets/javascripts
     depends_on:
       - postgres
       - mapfish-print


### PR DESCRIPTION
Supports #25.

Changes proposed in this pull request:
- Support npx webpack build without host side operation.
- Copy plugins folder inside `Dockerfile` to independent from `docker-compose.yml` volume mount.

@gtt-project/maintainer
