### PR TITLE
Update gtt plugin and limit postgis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     restart: always
 
   postgres:
-    image: postgis/postgis:latest
+    image: postgis/postgis:13-3.1
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
Changes proposed in this pull request:
- Update redmine_gtt plugin to 3.0.0.
- Limit postgis image tag from `latest` to `13-3.1`.

@gtt-project/maintainer
